### PR TITLE
Added comments to code sample and corrected single-quotes

### DIFF
--- a/_posts/2018-10-24-gomarkov.md
+++ b/_posts/2018-10-24-gomarkov.md
@@ -132,11 +132,13 @@ func NewChain(order int) *Chain {
 Now we need to create functions to add sequences to our markov chain and calculate the transition probability between two states:
 ```go
 //Add adds the transition counts to the chain for a given sequence of words
+// Implementation of the array(), concat(), and MakePairs() helper functions 
+// can be found in https://github.com/mb-14/gomarkov/blob/master/helpers.go
 func (chain *Chain) Add(sequence []string) {
 	// Pad the sequence with start and end tokens
 	// array(token, n) returns a array of length n filled with the token
-	startTokens := array('^', chain.Order)
-	endTokens := array('$', chain.Order)
+	startTokens := array("^", chain.Order)
+	endTokens := array("$", chain.Order)
 	tokens := concat(startTokens, sequence, endTokens)
 
 	// Extract n-grams from the sequence based on the chain order


### PR DESCRIPTION
Added comments in lines 135 136 to point reader to helper.go to find implementation details for array(), concat(), and MakePair(), without which the sample code cannot work. (Took a while for me to realise that you weren't referencing an obscure built-in).

Changed single-quotes to double-quotes in lines 140 141 so we're correctly taking in strings instead of runes.